### PR TITLE
Feature/improve command readability

### DIFF
--- a/src/main/java/com/omar/App.java
+++ b/src/main/java/com/omar/App.java
@@ -186,17 +186,12 @@ public class App {
     }
 
     public static void printAnime(Anime anime) {
-        System.out.println("");
-        System.out.println("- ↓ -----ANIME INFO----- ↓ -");
-        System.out.println("Id: " + anime.getId());
-        System.out.println("Name: " + anime.getName());
-        System.out.println("Status: " + anime.getStatus());
-        System.out.println("Score: " + anime.getScore());
-        System.out.println("Progress: " + anime.getProgress());
-        System.out.println("Episodes: " + anime.getEpisodes());
-        System.out.println("Genre: " + anime.getGenre());
-        System.out.println("- ↑ -----ANIME INFO----- ↑ -");
-        System.out.println("");
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("#%s %s (%s)\n", anime.getId(), anime.getName(), anime.getStatus().toString()));
+        sb.append("  Progress: ").append(anime.getProgress()).append("/").append(anime.getEpisodes()).append("\n");
+        sb.append("  Score: ").append(anime.getScore()).append("\n");
+        sb.append("  Genre: ").append(anime.getGenre()).append("\n");
+        System.out.println(sb.toString());
     }
 
     public static void printAnilist(List<Anime> animeList) {

--- a/src/main/java/com/omar/App.java
+++ b/src/main/java/com/omar/App.java
@@ -201,10 +201,7 @@ public class App {
         }
 
         for (Anime anime : animeList) {
-            System.out.println("");
-            System.out.println("Id: " + anime.getId());
-            System.out.println("Name: " + anime.getName());
-            System.out.println("");
+            System.out.println(String.format("#%s %s", anime.getId(), anime.getName()));
         }
     }
 


### PR DESCRIPTION
Esta petición de mezcla introduce pequeños cambios en el aspecto visual de la aplicación, con el propósito mejorar la legibilidad de los comandos `show` y` list`.

Esto esto se intenta aumentando el espacio horizontal que proporcionan los emuladores de consola y omitiendo textos que acompañen a información de la cual puede inferirse su origen, como puede ser el título de un anime o su estado.
También se ha introducido, tanto el los comandos `show` como `list` la notación de #<id> de forma que el usuario relacione estos símbolos con el id de un anime, evitando así la necesidad de indicar explícitamente que se trata de uno.

El resultado son comandos que, a mi parecer, resultan más legibles manteniendo toda la información que se mostraba anteriormente. Adjunto una comparativa de esto:

**Salida anterior ante el comando `show 1`**
``` 

- ↓ -----ANIME INFO----- ↓ -
Id: 1
Name: Ginga Eiyuu Densetsu
Status: COMPLETED
Score: 10
Progress: 110
Episodes: 110
Genre: KINOGRAPHY
- ↑ -----ANIME INFO----- ↑ -

``` 
**Salida del comando `show 1` tras aplicar estos cambios**
``` 
#1 Ginga Eiyuu Densetsu (COMPLETED)
  Progress: 110/110
  Score: 10
  Genre: KINOGRAPHY

```